### PR TITLE
Added single_account mode

### DIFF
--- a/awsenergylabelerlib/awsenergylabelerlib.py
+++ b/awsenergylabelerlib/awsenergylabelerlib.py
@@ -42,7 +42,7 @@ from .awsenergylabelerlibexceptions import (InvalidAccountListProvided,
                                             InvalidRegionListProvided,
                                             MutuallyExclusiveArguments)
 from .configuration import ACCOUNT_THRESHOLDS, LANDING_ZONE_THRESHOLDS, SECURITY_HUB_FILTER
-from .entities import SecurityHub, LandingZone
+from .entities import SecurityHub, LandingZone, AwsAccount
 from .schemas import account_thresholds_schema, security_hub_filter_schema, landing_zone_thresholds_schema
 
 __author__ = 'Costas Tyfoxylos <ctyfoxylos@schubergphilis.com>'
@@ -75,7 +75,8 @@ class EnergyLabeler:  # pylint: disable=too-many-instance-attributes, too-many-a
                  allow_list=None,
                  deny_list=None,
                  allowed_regions=None,
-                 denied_regions=None):
+                 denied_regions=None,
+                 single_account=False):
         if all([allow_list, deny_list]):
             raise MutuallyExclusiveArguments('allow_list and deny_list are mutually exclusive.')
         if all([allowed_regions, denied_regions]):
@@ -87,12 +88,12 @@ class EnergyLabeler:  # pylint: disable=too-many-instance-attributes, too-many-a
             else ACCOUNT_THRESHOLDS
         self.security_hub_filter = security_hub_filter_schema.validate(security_hub_filter) if security_hub_filter \
             else SECURITY_HUB_FILTER
-        self._landing_zone = LandingZone(landing_zone_name, self.landing_zone_thresholds, self.account_thresholds)
+        self._landing_zone = LandingZone(landing_zone_name, self.landing_zone_thresholds, self.account_thresholds) if not single_account else None
         self.allow_list = self._validate_account_ids(allow_list, self._landing_zone.account_ids) if allow_list else []
         self.deny_list = self._validate_account_ids(deny_list, self._landing_zone.account_ids) if deny_list else []
         self.allowed_regions = self._validate_regions(allowed_regions) if allowed_regions else []
         self.denied_regions = self._validate_regions(denied_regions) if denied_regions else []
-        self.landing_zone_name = landing_zone_name
+        self.landing_zone_name = landing_zone_name if not single_account else None
         self._security_hub = SecurityHub(query_filter=self.security_hub_filter,
                                          region=region,
                                          allowed_regions=self.allowed_regions,
@@ -100,6 +101,7 @@ class EnergyLabeler:  # pylint: disable=too-many-instance-attributes, too-many-a
         self._frameworks = frameworks if self._security_hub.validate_frameworks(frameworks) \
             else ('cis', 'aws-foundational-security-best-practices')  # pylint: disable=no-member
         self._account_labels_counter = None
+        self.single_account = single_account
 
     @property
     def security_hub_findings(self):
@@ -190,13 +192,20 @@ class EnergyLabeler:  # pylint: disable=too-many-instance-attributes, too-many-a
         labels = []
         self._logger.debug('Retrieving security hub findings')
         dataframe_measurements = pd.DataFrame(self.security_hub_measurement_data)
-        valid_account_ids = self._get_valid_account_ids()
-        for account in self._landing_zone.accounts:
-            self._logger.debug(f'Calculating energy label for account {account.id}')
-            labels.append(account.calculate_energy_label(dataframe_measurements))
-            if account.id in valid_account_ids:
-                self._logger.debug(f'Account id {account.id} is a required one, adding to the final report')
+        valid_account_ids = self._get_valid_account_ids() if not self.single_account else []
+        if self.single_account:
+            for account in dataframe_measurements['Account ID'].unique():
+                self._logger.debug(f'Calculating energy label for account {account}')
+                account = AwsAccount(account, account, None, self.account_thresholds)
+                labels.append(account.calculate_energy_label(dataframe_measurements))
                 labeled_accounts.append(account)
+        else:
+            for account in self._landing_zone.accounts:
+                self._logger.debug(f'Calculating energy label for account {account.id}')
+                labels.append(account.calculate_energy_label(dataframe_measurements))
+                if account.id in valid_account_ids:
+                    self._logger.debug(f'Account id {account.id} is a required one, adding to the final report')
+                    labeled_accounts.append(account)
         self._account_labels_counter.update(labels)
         return labeled_accounts
 

--- a/awsenergylabelerlib/awsenergylabelerlib.py
+++ b/awsenergylabelerlib/awsenergylabelerlib.py
@@ -94,7 +94,7 @@ class EnergyLabeler:  # pylint: disable=too-many-instance-attributes, too-many-a
         self.deny_list = self._validate_account_ids(deny_list, self._landing_zone.account_ids) if deny_list else []
         self.allowed_regions = self._validate_regions(allowed_regions) if allowed_regions else []
         self.denied_regions = self._validate_regions(denied_regions) if denied_regions else []
-        self.landing_zone_name = landing_zone_name if not single_account else None
+        self.landing_zone_name = landing_zone_name
         self._security_hub = SecurityHub(query_filter=self.security_hub_filter,
                                          region=region,
                                          allowed_regions=self.allowed_regions,

--- a/awsenergylabelerlib/awsenergylabelerlib.py
+++ b/awsenergylabelerlib/awsenergylabelerlib.py
@@ -88,7 +88,8 @@ class EnergyLabeler:  # pylint: disable=too-many-instance-attributes, too-many-a
             else ACCOUNT_THRESHOLDS
         self.security_hub_filter = security_hub_filter_schema.validate(security_hub_filter) if security_hub_filter \
             else SECURITY_HUB_FILTER
-        self._landing_zone = LandingZone(landing_zone_name, self.landing_zone_thresholds, self.account_thresholds) if not single_account else None
+        self._landing_zone = LandingZone(landing_zone_name, self.landing_zone_thresholds, self.account_thresholds) \
+            if not single_account else None
         self.allow_list = self._validate_account_ids(allow_list, self._landing_zone.account_ids) if allow_list else []
         self.deny_list = self._validate_account_ids(deny_list, self._landing_zone.account_ids) if deny_list else []
         self.allowed_regions = self._validate_regions(allowed_regions) if allowed_regions else []

--- a/awsenergylabelerlib/entities.py
+++ b/awsenergylabelerlib/entities.py
@@ -48,8 +48,6 @@ from .awsenergylabelerlibexceptions import (InvalidFrameworks,
                                             NoAccess,
                                             NoRegion)
 
-from .configuration import ACCOUNT_THRESHOLDS
-
 __author__ = 'Costas Tyfoxylos <ctyfoxylos@schubergphilis.com>'
 __docformat__ = '''google'''
 __date__ = '''09-11-2021'''
@@ -169,7 +167,6 @@ class AwsAccount:  # pylint: disable=too-many-instance-attributes
     number_of_medium_findings: int = 0
     number_of_low_findings: int = 0
     max_days_open: int = 0
-    
 
     def __post_init__(self):
         self._logger = logging.getLogger(f'{LOGGER_BASENAME}.{self.__class__.__name__}')

--- a/awsenergylabelerlib/entities.py
+++ b/awsenergylabelerlib/entities.py
@@ -48,6 +48,8 @@ from .awsenergylabelerlibexceptions import (InvalidFrameworks,
                                             NoAccess,
                                             NoRegion)
 
+from .configuration import ACCOUNT_THRESHOLDS
+
 __author__ = 'Costas Tyfoxylos <ctyfoxylos@schubergphilis.com>'
 __docformat__ = '''google'''
 __date__ = '''09-11-2021'''
@@ -123,7 +125,7 @@ class LandingZone:
         try:
             for page in iterator:
                 for account in page['Accounts']:
-                    account = AwsAccount(account.get('Id'), account.get('Name'), self)
+                    account = AwsAccount(account.get('Id'), account.get('Name'), self, self.account_thresholds)
                     aws_accounts.append(account)
             return aws_accounts
         except self.organizations.exceptions.AccessDeniedException as msg:
@@ -161,11 +163,13 @@ class AwsAccount:  # pylint: disable=too-many-instance-attributes
     id: str  # pylint: disable=invalid-name
     name: str
     landing_zone: LandingZone
+    account_thresholds: list
     energy_label: str = ""
     number_of_critical_high_findings: int = 0
     number_of_medium_findings: int = 0
     number_of_low_findings: int = 0
     max_days_open: int = 0
+    
 
     def __post_init__(self):
         self._logger = logging.getLogger(f'{LOGGER_BASENAME}.{self.__class__.__name__}')
@@ -204,7 +208,7 @@ class AwsAccount:  # pylint: disable=too-many-instance-attributes
                                    f'number of low findings {self.number_of_low_findings}, '
                                    f'and findings have been open for over '
                                    f'{self.max_days_open} days')
-                for threshold in self.landing_zone.account_thresholds:
+                for threshold in self.account_thresholds:
                     if self.number_of_critical_high_findings <= threshold['critical_high'] \
                             and self.number_of_medium_findings <= threshold['medium'] \
                             and self.number_of_low_findings <= threshold['low'] \


### PR DESCRIPTION
Introduced single account mode, which opportunisticly retrieves SecurityHub findings without cross checking the AWS Organization.