### PR TITLE
fixed bug where time field did not exist

### DIFF
--- a/awsenergylabelerlib/entities.py
+++ b/awsenergylabelerlib/entities.py
@@ -514,12 +514,18 @@ class Finding:  # pylint: disable=too-many-public-methods
     @property
     def first_observed_at(self):
         """First observed at."""
-        return self._parse_date_time(self._data.get('FirstObservedAt'))
+        if self._data.get('FirstObservedAt') != None:
+            return self._parse_date_time(self._data.get('FirstObservedAt'))
+        else:
+            return self._parse_date_time(self._data.get('CreatedAt'))
 
     @property
     def last_observed_at(self):
         """Last observed at."""
-        return self._parse_date_time(self._data.get('LastObservedAt'))
+        if self._data.get('LastObservedAt') != None:
+            return self._parse_date_time(self._data.get('LastObservedAt')) 
+        else:
+            return self._parse_date_time(self._data.get('UpdatedAt'))
 
     @property
     def created_at(self):

--- a/awsenergylabelerlib/entities.py
+++ b/awsenergylabelerlib/entities.py
@@ -514,18 +514,16 @@ class Finding:  # pylint: disable=too-many-public-methods
     @property
     def first_observed_at(self):
         """First observed at."""
-        if self._data.get('FirstObservedAt') != None:
-            return self._parse_date_time(self._data.get('FirstObservedAt'))
-        else:
+        if self._data.get('FirstObservedAt') is None:
             return self._parse_date_time(self._data.get('CreatedAt'))
+        return self._parse_date_time(self._data.get('FirstObservedAt'))
 
     @property
     def last_observed_at(self):
         """Last observed at."""
-        if self._data.get('LastObservedAt') != None:
-            return self._parse_date_time(self._data.get('LastObservedAt')) 
-        else:
+        if self._data.get('LastObservedAt') is None:
             return self._parse_date_time(self._data.get('UpdatedAt'))
+        return self._parse_date_time(self._data.get('LastObservedAt'))
 
     @property
     def created_at(self):


### PR DESCRIPTION
Encountered a bug where `FirstObservedAt` and `LastObservedAt` were not set in a finding.
`CreatedAt` and `UpdatedAt` do exist.

In the unlikely case `FirstObservedAt` and `LastObservedAt` don't exist, we can use `CreatedAt` and `UpdatedAt` fields and use those values for `FirstObservedAt` and `LastObservedAt` as well.

`FirstObservedAt` then seems logical to be set to `CreatedAt` as creation would indicate a first time seen

`LastObservedAt` seems logical to be set to `UpdatedAt` as the update would most likely be the last time the finding was observed.