### PR TITLE
Remove alias

### DIFF
--- a/awsenergylabelerlib/datamodels.py
+++ b/awsenergylabelerlib/datamodels.py
@@ -144,7 +144,7 @@ class LabeledAccountData:
     def data(self):
         """Data of an account to export."""
         return {'Account ID': self._labeled_account.id,
-                'Account Name (or alias if set)': self._labeled_account.alias or self._labeled_account.name,
+                'Account Name': self._labeled_account.name,
                 'Number of critical findings': self._labeled_account.energy_label.number_of_critical_findings,
                 'Number of high findings': self._labeled_account.energy_label.number_of_high_findings,
                 'Number of medium findings': self._labeled_account.energy_label.number_of_medium_findings,

--- a/awsenergylabelerlib/entities.py
+++ b/awsenergylabelerlib/entities.py
@@ -390,23 +390,8 @@ class AwsAccount:
         self.id = id_
         self.account_thresholds = account_thresholds
         self.name = name
-        self._alias = None
         self.energy_label = AccountEnergyLabel()
         self._logger = logging.getLogger(f'{LOGGER_BASENAME}.{self.__class__.__name__}')
-
-    @property
-    def alias(self):
-        """Alias."""
-        if self._alias is None:
-            self._alias = ''
-            try:
-                self._alias = boto3.client('iam').list_account_aliases()['AccountAliases'][0]
-            except IndexError:
-                LOGGER.debug(f'Alias for account {self.id} is not set.')
-            except botocore.exceptions.ClientError as msg:
-                LOGGER.warning(f'Alias for account {self.id} could not be retrieved with message {msg}, '
-                               f'no alias will be set.')
-        return self._alias
 
     def calculate_energy_label(self, findings):
         """Calculates the energy label for the account.


### PR DESCRIPTION
The alias functionality is strongly tied to IAM, while leveraging the organizations API we cannot retrieve others accounts' aliases.  Removing it and defaulting to account name seems most sensible.